### PR TITLE
Add total f-scores for multi-class problems

### DIFF
--- a/code/core/src/io/agi/framework/demo/mnist/ClassificationAnalysisEntity.java
+++ b/code/core/src/io/agi/framework/demo/mnist/ClassificationAnalysisEntity.java
@@ -116,7 +116,7 @@ public class ClassificationAnalysisEntity extends Entity {
         // F score and other stats, per label
         config.labelStatistics.clear();
         for( Float label : ca._sortedLabels ) {
-            ClassificationAnalysis.ClassificationStats labelStats = ca.new ClassificationStats(label);
+            ClassificationAnalysis.ClassificationStats labelStats = ca.getClassificationStats(label);
             // TODO: these should be declared with the interfaces, not concrete classes
             // TODO: why use strings?
             HashMap< String, String > labelStatMap = new HashMap<>();
@@ -126,9 +126,10 @@ public class ClassificationAnalysisEntity extends Entity {
             labelStatMap.put( "fp", String.valueOf( labelStats.getNumFalsePositives() ) );
             labelStatMap.put( "tn", String.valueOf( labelStats.getNumTrueNegatives() ) );
             labelStatMap.put( "fn", String.valueOf( labelStats.getNumFalseNegatives() ) );
-            labelStatMap.put( "f-score", String.valueOf( labelStats.getFScore( config.betaSq ) ) );
+            labelStatMap.put( "f-score", String.valueOf( labelStats.calculateFScore( config.betaSq ) ) );
             config.labelStatistics.put( String.valueOf( label ), labelStatMap );
         }
+        config.microFScore = ca.calculateFScore(0, ClassificationAnalysis.FScoreAverageType.MICRO );
+        config.macroFScore = ca.calculateFScore(0, ClassificationAnalysis.FScoreAverageType.MACRO );
     }
-
 }

--- a/code/core/src/io/agi/framework/demo/mnist/ClassificationAnalysisEntityConfig.java
+++ b/code/core/src/io/agi/framework/demo/mnist/ClassificationAnalysisEntityConfig.java
@@ -46,4 +46,6 @@ public class ClassificationAnalysisEntityConfig extends EntityConfig {
 
     public String resultsSummary = "";
 
+    public float microFScore = 0;
+    public float macroFScore = 0;
 }


### PR DESCRIPTION
This change adds micro & macro averaged f-scores ([story link](https://www.pivotaltracker.com/story/show/141096581)) while reducing duplication in calculation/presentation of classification stats and fixing some minor issues in the code.

I tested this by running a small phase 2 experiment, and verifying that the report gets printed to the log and the classification analysis config gets updated with the new output.

See also some inline comments/questions on the diff.